### PR TITLE
add linux support to detect usb device

### DIFF
--- a/src/port.rs
+++ b/src/port.rs
@@ -1,12 +1,20 @@
 use std::time::Duration;
-
+use std::env;
 use serialport::{Error, ErrorKind, Result, SerialPort, SerialPortType};
 
 use crate::common::MESSAGE_LENGTH;
 
 const MANUFACTURER_0: &str = "wch.cn";
 const MANUFACTURER_1: &str = "QinHeng Electronics";
+
+// see http://www.linux-usb.org/usb.ids for vendor id in hex 1A86
+const VENDOR_ID_LINUX: u16 = 0x1A86;
 const PRODUCT: &str = "CH340";
+
+// see http://www.linux-usb.org/usb.ids for device id in hex 7522
+const PRODUCT_ID_LINUX_1: u16 = 0x7523;
+// see http://www.linux-usb.org/usb.ids for device id in hex 7522
+const PRODUCT_ID_LINUX_2: u16 = 0x7522;
 
 const BAUD_RATE: u32 = 9600;
 const TIMEOUT_S: u64 = 1;
@@ -15,20 +23,30 @@ pub fn connect() -> Result<Box<dyn SerialPort>> {
     let mut result = Error::new(ErrorKind::NoDevice, "Cannot find power supply");
 
     let ports_visible = serialport::available_ports()?;
-
+    let is_linux = "linux".eq(env::consts::OS);
     for port_visible in ports_visible {
         match &port_visible.port_type {
             SerialPortType::UsbPort(usb_port_info) => {
-                match (&usb_port_info.manufacturer, &usb_port_info.product) {
-                    (Some(manufacturer), Some(product)) => {
-                        if !manufacturer.eq(MANUFACTURER_0) && !manufacturer.eq(MANUFACTURER_1) {
-                            continue;
-                        }
-                        if !product.contains(PRODUCT) {
-                            continue;
-                        }
+                if is_linux {
+                    if usb_port_info.vid != VENDOR_ID_LINUX {
+                        continue;
                     }
-                    _ => continue,
+                    if usb_port_info.pid != PRODUCT_ID_LINUX_1
+                        && usb_port_info.pid != PRODUCT_ID_LINUX_2 {
+                        continue;
+                    }
+                } else {
+                    match (&usb_port_info.manufacturer, &usb_port_info.product) {
+                        (Some(manufacturer), Some(product)) => {
+                            if !manufacturer.eq(MANUFACTURER_0) && !manufacturer.eq(MANUFACTURER_1) {
+                                continue;
+                            }
+                            if !product.contains(PRODUCT) {
+                                continue;
+                            }
+                        }
+                        _ => continue,
+                    }
                 }
             }
             _ => continue,


### PR DESCRIPTION
This PR adds initial support for Linux. Currently, automatic detection of the SerialPort is not working.  `serialport` displays the vendor-ID as the manufacturer and the product-ID as the product name. Both IDs can be referenced from [http://www.linux-usb.org/usb.ids](http://www.linux-usb.org/usb.ids). I used these ids to identify the device under Linux.

**Important:**
Before accessing the device, ensure that brltty is configured not to treat the device as a braille display. This issue is explained in detail here: [https://stackoverflow.com/questions/70123431/why-would-ch341-uart-be-disconnected-from-ttyusb](https://stackoverflow.com/questions/70123431/why-would-ch341-uart-be-disconnected-from-ttyusb)