### PR TITLE
ensure usb buffers are cleared between api calls

### DIFF
--- a/src/port.rs
+++ b/src/port.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use serialport::{Error, ErrorKind, Result, SerialPort, SerialPortType};
+use serialport::{ClearBuffer, Error, ErrorKind, Result, SerialPort, SerialPortType};
 
 use crate::common::MESSAGE_LENGTH;
 
@@ -38,7 +38,10 @@ pub fn connect() -> Result<Box<dyn SerialPort>> {
             .timeout(Duration::from_secs(TIMEOUT_S))
             .open()
         {
-            Ok(port) => return Ok(port),
+            Ok(port) => {
+                port.clear(ClearBuffer::All)?;
+                return Ok(port)
+            },
             Err(err) => result = err,
         }
     }


### PR DESCRIPTION
If the previous request was not completely processed, there is a possibility that the response from the old request was read instead of the response from the new request.